### PR TITLE
Test against latest marshmallow 2.0 release

### DIFF
--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -1,6 +1,11 @@
 from rest_marshmallow import Schema, fields
 
 
+import marshmallow
+
+IS_MARSHMALLOW_1 = marshmallow.__version__.split('.')[0] == '1'
+
+
 class Object(object):
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
@@ -64,8 +69,13 @@ def test_deserialize_validation_failed():
     data = {'number': 'abc', 'text': 'abc'}
     serializer = ExampleSerializer(data=data)
     assert not serializer.is_valid()
+    if IS_MARSHMALLOW_1:
+        expected_error = "invalid literal for int() with base 10: 'abc'"
+    else:
+        expected_error = 'Not a valid integer.'
+
     assert serializer.errors == {
-        'number': ["invalid literal for int() with base 10: 'abc'"]
+        'number': [expected_error]
     }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
        drf3.1: djangorestframework==3.1.3
        drf3.2: djangorestframework==3.2.3
        m1: marshmallow==1.2.6
-       m2: marshmallow==2.0.0b5
+       m2: marshmallow>=2.0.0rc1
        Django==1.8.4
        pytest-django==2.8.0
 


### PR DESCRIPTION
Tests against the latest marshmallow 2.0 release in tox and TCI. Fixes test for compat with 2.0.0rc1.
