### PR TITLE
Fix get_fields lookup

### DIFF
--- a/rest_marshmallow/__init__.py
+++ b/rest_marshmallow/__init__.py
@@ -1,5 +1,6 @@
 from rest_framework.serializers import BaseSerializer, ValidationError
 from marshmallow import Schema as MarshmallowSchema
+from marshmallow.utils import _Missing
 from marshmallow import fields  # noqa
 
 
@@ -32,6 +33,23 @@ class Schema(BaseSerializer, MarshmallowSchema):
         if ret.errors:
             raise ValidationError(ret.errors)
         return ret.data
+
+    def get_fields(self):
+        """
+        Returns a dictionary of {field_name: field_instance}.
+        Mapping certain marshmellow attributes to what their django
+        counterparts are so as to not break things
+        """        
+        fields = {}
+        for name, field in self.__class__._declared_fields.items():
+            if field.dump_only:
+                field.read_only = True
+            if field.load_only:
+                field.write_only = True
+            if isinstance(field, _Missing):
+                field.default = None
+            fields[name] = field
+        return fields
 
     @property
     def data(self):


### PR DESCRIPTION
Some other plugins that work with django rest framework need the get_fields method to do API introspection (django-rest-swagger)  This allows for that to continue to work without breaking because marshmallow has different ideas about serailizers read_only/write_only then django rest frameworks model serializers as it pertains to fields.  Also marshmallow's default class object of "Missing" does not serialize to JSON properly for django-rest-swagger.  This is the fix for that, but maybe it should actually be propegated down into that class in marshmallow.
