### PR TITLE
Bump pytest version to prevent error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ marshmallow==1.2.6
 
 # Test requirements
 pytest-django==2.8.0
-pytest==2.5.2
+pytest==2.9.1
 pytest-cov==1.6
 flake8==2.2.2
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly
 deps =
-       pytest==2.7.0
+       pytest==2.9.1
        flake8==2.4.0
 
 [testenv:py27-docs]


### PR DESCRIPTION
Running the `runtests` script was failing due to a pytest error:

```
(django-rest-marshmallow)~/p/p/django-rest-marshmallow ❯ ./runtests.py                                                                                                                               master
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.5.1 -- py-1.4.31 -- pytest-2.5.2 -- /Users/sloria/miniconda/envs/django-rest-marshmallow/bin/python
plugins: cov, django
collected 0 items / 1 errors

================================================================================================== ERRORS ==================================================================================================
________________________________________________________________________________ ERROR collecting tests/test_marshmallow.py ________________________________________________________________________________
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/py/_path/local.py:650: in pyimport
    __import__(modname)
<frozen importlib._bootstrap>:969: in _find_and_load
    ???
<frozen importlib._bootstrap>:954: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:892: in _find_spec
    ???
<frozen importlib._bootstrap>:873: in _find_spec_legacy
    ???
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:137: in find_module
    co = _rewrite_test(state, fn_pypath)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:269: in _rewrite_test
    rewrite_asserts(tree)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:322: in rewrite_asserts
    AssertionRewriter().run(mod)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:436: in run
    new.extend(self.visit(child))
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/ast.py:245: in visit
    return visitor(node)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:514: in visit_Assert
    top_condition, explanation = self.visit(assert_.test)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/ast.py:245: in visit
    return visitor(node)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:601: in visit_Call
    new_func, func_expl = self.visit(call.func)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/ast.py:245: in visit
    return visitor(node)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:631: in visit_Attribute
    value, value_expl = self.visit(attr.value)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/ast.py:245: in visit
    return visitor(node)
../../../miniconda/envs/django-rest-marshmallow/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:544: in visit_Name
    locs = ast.Call(self.builtin("locals"), [], [], None, None)
E   TypeError: Call constructor takes either 0 or 3 positional arguments
```

Bumping the pytest version to the latest version fixes this.
