### PR TITLE
Drop support for marshmallow 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,15 @@ sudo: false
 env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
-    - TOX_ENV=py27-m1-drf3.0
-    - TOX_ENV=py27-m1-drf3.1
-    - TOX_ENV=py27-m1-drf3.2
-    - TOX_ENV=py27-m2-drf3.0
-    - TOX_ENV=py27-m2-drf3.1
-    - TOX_ENV=py27-m2-drf3.2
-    - TOX_ENV=py33-m1-drf3.0
-    - TOX_ENV=py33-m1-drf3.1
-    - TOX_ENV=py33-m1-drf3.2
-    - TOX_ENV=py33-m2-drf3.0
-    - TOX_ENV=py33-m2-drf3.1
-    - TOX_ENV=py33-m2-drf3.2
-    - TOX_ENV=py34-m1-drf3.0
-    - TOX_ENV=py34-m1-drf3.1
-    - TOX_ENV=py34-m1-drf3.2
-    - TOX_ENV=py34-m2-drf3.0
-    - TOX_ENV=py34-m2-drf3.1
-    - TOX_ENV=py34-m2-drf3.2
+    - TOX_ENV=py27-drf3.0
+    - TOX_ENV=py27-drf3.1
+    - TOX_ENV=py27-drf3.2
+    - TOX_ENV=py33-drf3.0
+    - TOX_ENV=py33-drf3.1
+    - TOX_ENV=py33-drf3.2
+    - TOX_ENV=py34-drf3.0
+    - TOX_ENV=py34-drf3.1
+    - TOX_ENV=py34-drf3.2
 
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 * Python (2.7, 3.3+)
 * Django REST framework (3.0+)
-* Marshmallow (1.2+, 2.0+)
+* Marshmallow (2.0+)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@
 
 * Python (2.7, 3.3+)
 * Django REST framework (3.0+)
-* Marshmallow (1.2+, 2.0+)
+* Marshmallow (2.0+)
 
 ## Installation
 
@@ -161,6 +161,10 @@ $ mkdocs build
 ```
 
 ## Changelog
+
+### 2.0.0 (unreleased)
+
+* Drop support for marshmallow 1.x. Only marshmallow>=2.0.0 is supported.
 
 ### 1.0.1 (2016-10-02)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Minimum Django and REST framework version
 Django==1.8.4
 djangorestframework==3.2.3
-marshmallow==1.2.6
+marshmallow==2.0.0
 
 # Test requirements
 pytest-django==2.8.0

--- a/rest_marshmallow/__init__.py
+++ b/rest_marshmallow/__init__.py
@@ -1,13 +1,9 @@
 from rest_framework.serializers import BaseSerializer, ValidationError
 
-import marshmallow
 from marshmallow import Schema as MarshmallowSchema
 from marshmallow import fields  # noqa
 
-
 __version__ = '1.0.1'
-
-MARSHMALLOW_VERSION = int(marshmallow.__version__.split('.')[0])
 
 _schema_kwargs = (
     'only', 'exclude'
@@ -67,6 +63,4 @@ class Schema(BaseSerializer, MarshmallowSchema):
     def context(self, value):
         self._context = value
 
-    if MARSHMALLOW_VERSION >= 2:
-        # Ensure that marshmallow's get_attribute is used rather than DRF's
-        get_attribute = MarshmallowSchema.get_attribute
+    get_attribute = MarshmallowSchema.get_attribute

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-m{1,2}-drf{3.0,3.1,3.2}
+       {py27,py33,py34}-drf{3.0,3.1,3.2}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -11,8 +11,7 @@ deps =
        drf3.0: djangorestframework==3.0.5
        drf3.1: djangorestframework==3.1.3
        drf3.2: djangorestframework==3.2.3
-       m1: marshmallow==1.2.6
-       m2: marshmallow>=2.0.0rc1
+       marshmallow>=2.0.0
        Django==1.8.4
        pytest-django==2.8.0
 


### PR DESCRIPTION
There hasn't been activity on the marshmallow 1.x line for over a year now; it's high time to drop support for "legacy" marshmallow =)
