### PR TITLE
Test updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,13 @@ env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
     - TOX_ENV=py27-drf3.0
-    - TOX_ENV=py27-drf3.1
-    - TOX_ENV=py27-drf3.2
-    # py33
-    - TOX_ENV=py33-drf3.0
-    - TOX_ENV=py33-drf3.1
-    - TOX_ENV=py33-drf3.2
+    - TOX_ENV=py27-drf3.4
     # py34
     - TOX_ENV=py34-drf3.0
-    - TOX_ENV=py34-drf3.1
-    - TOX_ENV=py34-drf3.2
+    - TOX_ENV=py34-drf3.4
     # py35
     - TOX_ENV=py35-drf3.0
-    - TOX_ENV=py35-drf3.1
-    - TOX_ENV=py35-drf3.2
+    - TOX_ENV=py35-drf3.4
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,29 @@
 language: python
 
+python:
+    - "3.5"
+
 sudo: false
 
 env:
+    # py27
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
     - TOX_ENV=py27-drf3.0
     - TOX_ENV=py27-drf3.1
     - TOX_ENV=py27-drf3.2
+    # py33
     - TOX_ENV=py33-drf3.0
     - TOX_ENV=py33-drf3.1
     - TOX_ENV=py33-drf3.2
+    # py34
     - TOX_ENV=py34-drf3.0
     - TOX_ENV=py34-drf3.1
     - TOX_ENV=py34-drf3.2
+    # py35
+    - TOX_ENV=py35-drf3.0
+    - TOX_ENV=py35-drf3.1
+    - TOX_ENV=py35-drf3.2
 
 
 matrix:

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,6 +165,8 @@ $ mkdocs build
 ### 2.0.0 (unreleased)
 
 * Drop support for marshmallow 1.x. Only marshmallow>=2.0.0 is supported.
+* Officially support Python 3.4 and 3.5.
+* Drop support for Python 3.3 (which is no longer supported by Django).
 
 ### 1.0.1 (2016-10-02)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@ djangorestframework==3.2.3
 marshmallow==2.0.0
 
 # Test requirements
-pytest-django==2.8.0
-pytest==2.9.1
-pytest-cov==1.6
-flake8==2.2.2
+pytest-django==3.0.0
+pytest==3.0.3
+pytest-cov==2.3.1
+flake8==3.0.4
 
 # wheel for PyPI installs
 wheel==0.24.0
 
 # MkDocs for documentation
-mkdocs==0.11.1
+mkdocs==0.15.3

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34,py35}-drf{3.0,3.1,3.2}
+       {py27,py34,py35}-drf{3.0,3.4}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -9,8 +9,7 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
        drf3.0: djangorestframework==3.0.5
-       drf3.1: djangorestframework==3.1.3
-       drf3.2: djangorestframework==3.2.3
+       drf3.4: djangorestframework==3.4.7
        marshmallow>=2.0.0
        Django==1.8.4
        pytest-django==2.8.0
@@ -18,8 +17,8 @@ deps =
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly
 deps =
-       pytest==2.9.1
-       flake8==2.4.0
+       pytest==3.0.3
+       flake8==3.0.4
 
 [testenv:py27-docs]
 commands = mkdocs build

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-drf{3.0,3.1,3.2}
+       {py27,py33,py34,py35}-drf{3.0,3.1,3.2}
 
 [testenv]
 commands = ./runtests.py --fast


### PR DESCRIPTION
- [x] Test against Python 3.5
- [x] Test against latest version(s) of DRF
- [x] Updated outdated requirements
- [x] Drop support for py3.3, which is not supported by Django
