### PR TITLE
Add support to marshmallow 3 (gt 3.0.07b)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Minimum Django and REST framework version
 Django==1.8.4
 djangorestframework==3.2.3
-marshmallow==2.0.0
+marshmallow>=2.0.0
 
 # Test requirements
 pytest-django==3.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py34,py35,py36}-drf{3.4,3.6}
+       {py27,py34,py35,py36}-drf{3.4,3.6}-marshmallow{2,3}
 
 [travis:env]
 DRF =
@@ -15,7 +15,8 @@ setenv =
 deps =
        drf3.4: djangorestframework==3.4.7
        drf3.6: djangorestframework==3.6.3
-       marshmallow>=2.0.0
+       marshmallow2: marshmallow>=2.0.0
+       marshmallow3: marshmallow==3.0.0b7
        Django==1.10
        pytest-django==2.8.0
 


### PR DESCRIPTION
Add support to marshmallow 3.0.0 (gt 3.0.07b):
- Backwards-incompatible: Schema().load and Schema().dump return data instead of a (data, errors) duple (#598).
- Backwards-incomaptible: Schema().load(None) raises a ValidationError (#511).

Still supports old marshmallow versions via IS_MARSHMALLOW_LT_3 variable (note sur it's the good way to do it, maybe a new version is a better idea)