### PR TITLE
Add support for fields.Nested with many=True

### DIFF
--- a/rest_marshmallow/__init__.py
+++ b/rest_marshmallow/__init__.py
@@ -16,6 +16,13 @@ _schema_kwargs = (
 
 
 class Schema(BaseSerializer, MarshmallowSchema):
+
+    def __new__(cls, *args, **kwargs):
+        # We're overriding the DRF implementation here, because ListSerializer
+        # clashes with Nested implementation.
+        kwargs.pop('many', False)
+        return super(Schema, cls).__new__(cls, *args, **kwargs)
+
     def __init__(self, *args, **kwargs):
         schema_kwargs = {
             'many': kwargs.get('many', False)

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -30,6 +30,11 @@ class NestedSerializer(Schema):
     child = fields.Nested(ExampleSerializer)
 
 
+class ManyNestedSerializer(Schema):
+    top = fields.Integer()
+    children = fields.Nested(ExampleSerializer, many=True)
+
+
 def test_serialize():
     instance = Object(number=123, text='abc')
     serializer = ExampleSerializer(instance)
@@ -50,6 +55,16 @@ def test_serialize_many():
         {'number': 123, 'text': 'abc'},
         {'number': 123, 'text': 'abc'},
     ]
+
+
+def test_serialize_nested_many():
+    instance = Object(top=1, children=[Object(number=123, text='abc') for i in range(3)])
+    serializer = ManyNestedSerializer(instance)
+    assert serializer.data == {'top': 1, 'children': [
+        {'number': 123, 'text': 'abc'},
+        {'number': 123, 'text': 'abc'},
+        {'number': 123, 'text': 'abc'},
+    ]}
 
 
 def test_serialize_only():


### PR DESCRIPTION
Fix #72 by disabling ListSerializer initialization. Although this solution passes all tests, it is not perfect because methods create/update/save would not work properly with many=True, but I could not find a better solution.